### PR TITLE
Introduce mergeSchemas

### DIFF
--- a/src/epoxy/index.ts
+++ b/src/epoxy/index.ts
@@ -1,3 +1,3 @@
-export { mergeTypeDefs } from './typedefs-mergers/merge-typedefs';
+export { mergeTypeDefs, mergeGraphQLSchemas } from './typedefs-mergers/merge-typedefs';
 export { mergeResolvers } from './resolvers-mergers/merge-resolvers';
 export { mergeSchemas } from './merge-schemas';

--- a/src/epoxy/index.ts
+++ b/src/epoxy/index.ts
@@ -1,2 +1,3 @@
-export { mergeGraphQLSchemas } from './schema-mergers/merge-schema';
+export { mergeTypeDefs } from './typedefs-mergers/merge-typedefs';
 export { mergeResolvers } from './resolvers-mergers/merge-resolvers';
+export { mergeSchemas } from './merge-schemas';

--- a/src/epoxy/merge-schemas.ts
+++ b/src/epoxy/merge-schemas.ts
@@ -1,32 +1,43 @@
 import { GraphQLSchema, DocumentNode } from "graphql";
-import { IResolvers, SchemaDirectiveVisitor, makeExecutableSchema, IResolverValidationOptions } from "graphql-tools";
+import { IResolvers, SchemaDirectiveVisitor, makeExecutableSchema, IResolverValidationOptions, ILogger } from "graphql-tools";
 import { mergeTypeDefs } from "./typedefs-mergers/merge-typedefs";
 import { asArray } from "../utils/helpers";
 import { mergeResolvers } from "./resolvers-mergers/merge-resolvers";
-import { extractResolversFromSchema } from "../utils";
+import { extractResolversFromSchema, IResolversComposerMapping, composeResolvers } from "../utils";
 
 export interface MergeSchemasConfig {
     schemas: GraphQLSchema[];
     typeDefs?: (DocumentNode | string)[] | DocumentNode | string;
     resolvers?: IResolvers | IResolvers[];
+    resolversComposition?: IResolversComposerMapping;
     schemaDirectives ?: { [directiveName: string] : typeof SchemaDirectiveVisitor };
     resolverValidationOptions ?: IResolverValidationOptions;
+    logger?: ILogger;
 }
 
-export function mergeSchemas(config: MergeSchemasConfig) {
-    const typeDefs = mergeTypeDefs([
-        ...config.schemas,
-        ...config.typeDefs ? asArray(config.typeDefs) : []
-    ]);
-    const resolvers = mergeResolvers([
-        ...config.schemas.map(schema => extractResolversFromSchema(schema)),
-        ...config.resolvers ? asArray<IResolvers>(config.resolvers) : []
-    ]);
-    
+export function mergeSchemas({
+    schemas,
+    typeDefs,
+    resolvers,
+    resolversComposition,
+    schemaDirectives,
+    resolverValidationOptions,
+    logger
+}: MergeSchemasConfig) {
     return makeExecutableSchema({
-        typeDefs,
-        resolvers,
-        schemaDirectives: config.schemaDirectives,
-        resolverValidationOptions: config.resolverValidationOptions
+        typeDefs: mergeTypeDefs([
+            ...schemas,
+            ...typeDefs ? asArray(typeDefs) : []
+        ]),
+        resolvers: composeResolvers(
+                mergeResolvers([
+                ...schemas.map(schema => extractResolversFromSchema(schema)),
+                ...resolvers ? asArray<IResolvers>(resolvers) : []
+            ]),
+            resolversComposition || {}
+        ),
+        schemaDirectives,
+        resolverValidationOptions,
+        logger
     })
 }

--- a/src/epoxy/merge-schemas.ts
+++ b/src/epoxy/merge-schemas.ts
@@ -1,0 +1,32 @@
+import { GraphQLSchema, DocumentNode } from "graphql";
+import { IResolvers, SchemaDirectiveVisitor, makeExecutableSchema, IResolverValidationOptions } from "graphql-tools";
+import { mergeTypeDefs } from "./typedefs-mergers/merge-typedefs";
+import { asArray } from "../utils/helpers";
+import { mergeResolvers } from "./resolvers-mergers/merge-resolvers";
+import { extractResolversFromSchema } from "../utils";
+
+export interface MergeSchemasConfig {
+    schemas: GraphQLSchema[];
+    typeDefs?: (DocumentNode | string)[] | DocumentNode | string;
+    resolvers?: IResolvers | IResolvers[];
+    schemaDirectives ?: { [directiveName: string] : typeof SchemaDirectiveVisitor };
+    resolverValidationOptions ?: IResolverValidationOptions;
+}
+
+export function mergeSchemas(config: MergeSchemasConfig) {
+    const typeDefs = mergeTypeDefs([
+        ...config.schemas,
+        ...config.typeDefs ? asArray(config.typeDefs) : []
+    ]);
+    const resolvers = mergeResolvers([
+        ...config.schemas.map(schema => extractResolversFromSchema(schema)),
+        ...config.resolvers ? asArray<IResolvers>(config.resolvers) : []
+    ]);
+    
+    return makeExecutableSchema({
+        typeDefs,
+        resolvers,
+        schemaDirectives: config.schemaDirectives,
+        resolverValidationOptions: config.resolverValidationOptions
+    })
+}

--- a/src/epoxy/typedefs-mergers/directives.ts
+++ b/src/epoxy/typedefs-mergers/directives.ts
@@ -1,0 +1,79 @@
+import { ArgumentNode, DirectiveNode } from 'graphql/language/ast';
+import { DirectiveDefinitionNode, ListValueNode, NameNode, print } from 'graphql';
+
+function directiveAlreadyExists(directivesArr: ReadonlyArray<DirectiveNode>, otherDirective: DirectiveNode): boolean {
+  return !!directivesArr.find(directive => directive.name.value === otherDirective.name.value);
+}
+
+function nameAlreadyExists(name: NameNode, namesArr: ReadonlyArray<NameNode>): boolean {
+  return namesArr.some(({ value }) => value === name.value);
+}
+
+function mergeArguments(a1: ArgumentNode[], a2: ArgumentNode[]): ArgumentNode[] {
+  const result: ArgumentNode[] = [...a2];
+
+  for (const argument of a1) {
+    const existingIndex = result.findIndex(a => a.name.value === argument.name.value);
+
+    if (existingIndex > -1) {
+      const existingArg = result[existingIndex];
+
+      if (existingArg.value.kind === 'ListValue') {
+        (existingArg.value as any).values = [
+          ...existingArg.value.values,
+          ...(argument.value as ListValueNode).values,
+        ];
+      } else {
+        (existingArg as any).value = argument.value;
+      }
+    } else {
+      result.push(argument);
+    }
+  }
+
+  return result;
+}
+
+export function mergeDirectives(d1: ReadonlyArray<DirectiveNode>, d2: ReadonlyArray<DirectiveNode>): DirectiveNode[] {
+  const result = [...d2];
+
+  for (const directive of d1) {
+    if (directiveAlreadyExists(result, directive)) {
+      const existingDirectiveIndex = result.findIndex(d => d.name.value === directive.name.value);
+      const existingDirective = result[existingDirectiveIndex];
+      (result[existingDirectiveIndex] as any).arguments = mergeArguments(existingDirective.arguments as any, directive.arguments as any);
+    } else {
+      result.push(directive);
+    }
+  }
+
+  return result;
+}
+
+function validateInputs(node: DirectiveDefinitionNode, existingNode: DirectiveDefinitionNode): void | never {
+  const printedNode = print(node);
+  const printedExistingNode = print(existingNode);
+  const leaveInputs = new RegExp('(directive @\w*\d*)|( on .*$)', 'g');
+  const sameArguments = printedNode.replace(leaveInputs, '') === printedExistingNode.replace(leaveInputs, '');
+
+  if (!sameArguments) {
+    throw new Error(`Unable to merge GraphQL directive "${node.name.value}". \nExisting directive:  \n\t${printedExistingNode} \nReceived directive: \n\t${printedNode}`);
+  }
+}
+
+export function mergeDirective(node: DirectiveDefinitionNode, existingNode?: DirectiveDefinitionNode): DirectiveDefinitionNode {
+  if (existingNode) {
+
+    validateInputs(node, existingNode);
+
+    return {
+      ...node,
+      locations: [
+        ...existingNode.locations,
+        ...(node.locations.filter(name => !nameAlreadyExists(name, existingNode.locations))),
+      ],
+    };
+  }
+
+  return node;
+}

--- a/src/epoxy/typedefs-mergers/enum-values.ts
+++ b/src/epoxy/typedefs-mergers/enum-values.ts
@@ -1,0 +1,12 @@
+import { EnumValueDefinitionNode } from 'graphql/language/ast';
+
+function alreadyExists(arr: ReadonlyArray<EnumValueDefinitionNode>, other: EnumValueDefinitionNode): boolean {
+  return !!arr.find(v => v.name.value === other.name.value);
+}
+
+export function mergeEnumValues(first: ReadonlyArray<EnumValueDefinitionNode>, second: ReadonlyArray<EnumValueDefinitionNode>): EnumValueDefinitionNode[] {
+  return [
+    ...second,
+    ...(first.filter(d => !alreadyExists(second, d))),
+  ];
+}

--- a/src/epoxy/typedefs-mergers/enum.ts
+++ b/src/epoxy/typedefs-mergers/enum.ts
@@ -1,0 +1,20 @@
+import { EnumTypeDefinitionNode, EnumTypeExtensionNode } from 'graphql';
+import { mergeDirectives } from './directives';
+import { mergeEnumValues } from './enum-values';
+
+export function mergeEnum(e1: EnumTypeDefinitionNode | EnumTypeExtensionNode, e2: EnumTypeDefinitionNode | EnumTypeExtensionNode): EnumTypeDefinitionNode | EnumTypeExtensionNode {
+
+  if (e2) {
+    return {
+      name: e1.name,
+      description: e1['description'] || e2['description'],
+      kind: (e1.kind === 'EnumTypeDefinition' || e2.kind === 'EnumTypeDefinition') ? 'EnumTypeDefinition' : 'EnumTypeExtension',
+      loc: e1.loc,
+      directives: mergeDirectives(e1.directives, e2.directives),
+      values: mergeEnumValues(e1.values, e2.values),
+    } as any;
+  }
+
+  return e1;
+
+}

--- a/src/epoxy/typedefs-mergers/fields.ts
+++ b/src/epoxy/typedefs-mergers/fields.ts
@@ -1,0 +1,33 @@
+import { FieldDefinitionNode } from 'graphql/language/ast';
+import { extractType } from './utils';
+import { mergeDirectives } from './directives';
+
+function fieldAlreadyExists(fieldsArr: ReadonlyArray<any>, otherField: any): boolean {
+  const result: FieldDefinitionNode | null = fieldsArr.find(field => field.name.value === otherField.name.value);
+
+  if (result) {
+    const t1 = extractType(result.type);
+    const t2 = extractType(otherField.type);
+
+    if (t1.name.value !== t2.name.value) {
+      throw new Error(`Field "${otherField.name.value}" already defined with a different type. Declared as "${t1.name.value}", but you tried to override with "${t2.name.value}"`);
+    }
+  }
+
+  return !!result;
+}
+
+export function mergeFields<T>(f1: ReadonlyArray<T>, f2: ReadonlyArray<T>): T[] {
+  const result: T[] = [...f2];
+
+  for (const field of f1) {
+    if (fieldAlreadyExists(result, field)) {
+      const existing = result.find((f: any) => f.name.value === (field as any).name.value);
+      existing['directives'] = mergeDirectives(field['directives'], existing['directives']);
+    } else {
+      result.push(field);
+    }
+  }
+
+  return result;
+}

--- a/src/epoxy/typedefs-mergers/input-type.ts
+++ b/src/epoxy/typedefs-mergers/input-type.ts
@@ -1,0 +1,26 @@
+import { InputObjectTypeDefinitionNode } from 'graphql';
+import { mergeFields } from './fields';
+import { mergeDirectives } from './directives';
+import { InputValueDefinitionNode, InputObjectTypeExtensionNode } from 'graphql/language/ast';
+
+export function mergeInputType(
+  node: InputObjectTypeDefinitionNode | InputObjectTypeExtensionNode,
+  existingNode: InputObjectTypeDefinitionNode | InputObjectTypeExtensionNode): InputObjectTypeDefinitionNode | InputObjectTypeExtensionNode {
+
+  if (existingNode) {
+    try {
+      return {
+        name: node.name,
+        description: node['description'] || existingNode['description'],
+        kind: (node.kind === 'InputObjectTypeDefinition' || existingNode.kind === 'InputObjectTypeDefinition') ? 'InputObjectTypeDefinition' : 'InputObjectTypeExtension',
+        loc: node.loc,
+        fields: mergeFields<InputValueDefinitionNode>(node.fields, existingNode.fields),
+        directives: mergeDirectives(node.directives, existingNode.directives),
+      } as any;
+    } catch (e) {
+      throw new Error(`Unable to merge GraphQL input type "${node.name.value}": ${e.message}`);
+    }
+  }
+
+  return node;
+}

--- a/src/epoxy/typedefs-mergers/interface.ts
+++ b/src/epoxy/typedefs-mergers/interface.ts
@@ -1,0 +1,25 @@
+import { InterfaceTypeDefinitionNode, InterfaceTypeExtensionNode } from 'graphql';
+import { mergeFields } from './fields';
+import { mergeDirectives } from './directives';
+
+export function mergeInterface(
+  node: InterfaceTypeDefinitionNode | InterfaceTypeExtensionNode,
+  existingNode: InterfaceTypeDefinitionNode | InterfaceTypeExtensionNode): InterfaceTypeDefinitionNode | InterfaceTypeExtensionNode {
+
+  if (existingNode) {
+    try {
+      return {
+        name: node.name,
+        description: node['description'] || existingNode['description'],
+        kind: (node.kind === 'InterfaceTypeDefinition' || existingNode.kind === 'InterfaceTypeDefinition') ? 'InterfaceTypeDefinition' : 'InterfaceTypeExtension',
+        loc: node.loc,
+        fields: mergeFields(node.fields, existingNode.fields),
+        directives: mergeDirectives(node.directives, existingNode.directives),
+      } as any;
+    } catch (e) {
+      throw new Error(`Unable to merge GraphQL interface "${node.name.value}": ${e.message}`);
+    }
+  }
+
+  return node;
+}

--- a/src/epoxy/typedefs-mergers/merge-named-type-array.ts
+++ b/src/epoxy/typedefs-mergers/merge-named-type-array.ts
@@ -1,0 +1,12 @@
+import { NamedTypeNode } from 'graphql/language/ast';
+
+function alreadyExists(arr: ReadonlyArray<NamedTypeNode>, other: NamedTypeNode): boolean {
+  return !!arr.find(i => i.name.value === other.name.value);
+}
+
+export function mergeNamedTypeArray(first: ReadonlyArray<NamedTypeNode>, second: ReadonlyArray<NamedTypeNode>): NamedTypeNode[] {
+  return [
+    ...second,
+    ...(first.filter(d => !alreadyExists(second, d))),
+  ];
+}

--- a/src/epoxy/typedefs-mergers/merge-nodes.ts
+++ b/src/epoxy/typedefs-mergers/merge-nodes.ts
@@ -1,0 +1,52 @@
+import { DefinitionNode } from 'graphql';
+import {
+  isGraphQLEnum,
+  isGraphQLInputType,
+  isGraphQLInterface,
+  isGraphQLScalar,
+  isGraphQLType,
+  isGraphQLUnion,
+  isGraphQLDirective,
+  isGraphQLTypeExtension,
+  isGraphQLInputTypeExtension,
+  isGraphQLEnumExtension,
+  isGraphQLUnionExtension,
+  isGraphQLScalarExtension,
+  isGraphQLInterfaceExtension,
+} from './utils';
+import { mergeType } from './type';
+import { mergeEnum } from './enum';
+import { mergeUnion } from './union';
+import { mergeInputType } from './input-type';
+import { mergeInterface } from './interface';
+import { mergeDirective } from './directives';
+
+export type MergedResultMap = {[name: string]: DefinitionNode};
+
+export function mergeGraphQLNodes(nodes: ReadonlyArray<DefinitionNode>): MergedResultMap {
+  return nodes.reduce<MergedResultMap>((prev: MergedResultMap, nodeDefinition: DefinitionNode) => {
+    const node = (nodeDefinition as any);
+
+    if (node && node.name && node.name.value) {
+      const name = node.name.value;
+
+      if (isGraphQLType(nodeDefinition) || isGraphQLTypeExtension(nodeDefinition)) {
+        prev[name] = mergeType(nodeDefinition, prev[name] as any);
+      } else if (isGraphQLEnum(nodeDefinition) || isGraphQLEnumExtension(nodeDefinition)) {
+        prev[name] = mergeEnum(nodeDefinition, prev[name] as any);
+      } else if (isGraphQLUnion(nodeDefinition) || isGraphQLUnionExtension(nodeDefinition)) {
+        prev[name] = mergeUnion(nodeDefinition, prev[name] as any);
+      } else if (isGraphQLScalar(nodeDefinition) || isGraphQLScalarExtension(nodeDefinition)) {
+        prev[name] = nodeDefinition;
+      } else if (isGraphQLInputType(nodeDefinition) || isGraphQLInputTypeExtension(nodeDefinition)) {
+        prev[name] = mergeInputType(nodeDefinition, prev[name] as any);
+      } else if (isGraphQLInterface(nodeDefinition) || isGraphQLInterfaceExtension(nodeDefinition)) {
+        prev[name] = mergeInterface(nodeDefinition, prev[name] as any);
+      } else if (isGraphQLDirective(nodeDefinition)) {
+        prev[name] = mergeDirective(nodeDefinition, prev[name] as any);
+      }
+    }
+
+    return prev;
+  }, {});
+}

--- a/src/epoxy/typedefs-mergers/merge-typedefs.ts
+++ b/src/epoxy/typedefs-mergers/merge-typedefs.ts
@@ -22,7 +22,7 @@ interface Config {
   useSchemaDefinition?: boolean;
 }
 
-export function mergeGraphQLSchemas(types: Array<string | Source | DocumentNode | GraphQLSchema>, config?: Partial<Config>): DocumentNode {
+export function mergeTypeDefs(types: Array<string | Source | DocumentNode | GraphQLSchema>, config?: Partial<Config>): DocumentNode {
   return {
     kind: 'Document',
     definitions: mergeGraphQLTypes(types, {

--- a/src/epoxy/typedefs-mergers/merge-typedefs.ts
+++ b/src/epoxy/typedefs-mergers/merge-typedefs.ts
@@ -22,6 +22,16 @@ interface Config {
   useSchemaDefinition?: boolean;
 }
 
+export function mergeGraphQLSchemas(...args: ArgsType<typeof mergeGraphQLTypes>): ReturnType<typeof mergeGraphQLTypes> {
+  console.info(`
+    GraphQL Toolkit/Epoxy 
+    Deprecation Notice;
+    'mergeGraphQLSchemas' is deprecated and will be removed in the next version.
+    Please use 'mergeTypeDefs' instead!
+  `);
+  return mergeGraphQLTypes(...args);
+}
+
 export function mergeTypeDefs(types: Array<string | Source | DocumentNode | GraphQLSchema>, config?: Partial<Config>): DocumentNode {
   return {
     kind: 'Document',

--- a/src/epoxy/typedefs-mergers/type.ts
+++ b/src/epoxy/typedefs-mergers/type.ts
@@ -1,0 +1,24 @@
+import { ObjectTypeDefinitionNode, ObjectTypeExtensionNode } from 'graphql';
+import { mergeFields } from './fields';
+import { mergeDirectives } from './directives';
+import { mergeNamedTypeArray } from './merge-named-type-array';
+
+export function mergeType(node: ObjectTypeDefinitionNode | ObjectTypeExtensionNode, existingNode: ObjectTypeDefinitionNode | ObjectTypeExtensionNode): ObjectTypeDefinitionNode | ObjectTypeExtensionNode {
+  if (existingNode) {
+    try {
+      return {
+        name: node.name,
+        description: node['description'] || existingNode['description'],
+        kind: (node.kind === 'ObjectTypeDefinition' || existingNode.kind === 'ObjectTypeDefinition') ? 'ObjectTypeDefinition' : 'ObjectTypeExtension',
+        loc: node.loc,
+        fields: mergeFields(node.fields, existingNode.fields),
+        directives: mergeDirectives(node.directives, existingNode.directives),
+        interfaces: mergeNamedTypeArray(node.interfaces, existingNode.interfaces),
+      } as any;
+    } catch (e) {
+      throw new Error(`Unable to merge GraphQL type "${node.name.value}": ${e.message}`);
+    }
+  }
+
+  return node;
+}

--- a/src/epoxy/typedefs-mergers/union.ts
+++ b/src/epoxy/typedefs-mergers/union.ts
@@ -1,0 +1,22 @@
+import { UnionTypeDefinitionNode, UnionTypeExtensionNode } from 'graphql';
+import { mergeDirectives } from './directives';
+import { mergeNamedTypeArray } from './merge-named-type-array';
+
+export function mergeUnion(first: UnionTypeDefinitionNode | UnionTypeExtensionNode, second: UnionTypeDefinitionNode | UnionTypeExtensionNode): UnionTypeDefinitionNode | UnionTypeExtensionNode {
+  if (second) {
+    return {
+      name: first.name,
+      description: first['description'] || second['description'],
+      directives: mergeDirectives(first.directives, second.directives),
+      kind: (first.kind === 'UnionTypeDefinition' || second.kind === 'UnionTypeDefinition') ? 'UnionTypeDefinition' : 'UnionTypeExtension',
+      loc: first.loc,
+      types: mergeNamedTypeArray(first.types, second.types),
+    } as any;
+  }
+
+  if (first.kind === 'UnionTypeExtension') {
+    throw new Error(`Unable to extend undefined GraphQL union: ${first.name}`);
+  }
+
+  return first;
+}

--- a/src/epoxy/typedefs-mergers/utils.ts
+++ b/src/epoxy/typedefs-mergers/utils.ts
@@ -1,0 +1,99 @@
+import {
+  TypeNode,
+  DefinitionNode,
+  EnumTypeDefinitionNode,
+  NamedTypeNode,
+  ObjectTypeDefinitionNode,
+  Source,
+  UnionTypeDefinitionNode,
+  ScalarTypeDefinitionNode,
+  InputObjectTypeDefinitionNode,
+  GraphQLSchema,
+  InterfaceTypeDefinitionNode,
+  DirectiveDefinitionNode,
+  SchemaDefinitionNode,
+  ObjectTypeExtensionNode,
+  InputObjectTypeExtensionNode,
+  EnumTypeExtensionNode,
+  UnionTypeExtensionNode,
+  ScalarTypeExtensionNode,
+  InterfaceTypeExtensionNode,
+} from 'graphql';
+
+export function isStringTypes(types: any): types is string {
+  return typeof types === 'string';
+}
+
+export function isSourceTypes(types: any): types is Source {
+  return types instanceof Source;
+}
+
+export function isGraphQLType(definition: DefinitionNode): definition is ObjectTypeDefinitionNode {
+  return definition.kind === 'ObjectTypeDefinition';
+}
+
+export function isGraphQLTypeExtension(definition: DefinitionNode): definition is ObjectTypeExtensionNode {
+  return definition.kind === 'ObjectTypeExtension';
+}
+
+export function isGraphQLEnum(definition: DefinitionNode): definition is EnumTypeDefinitionNode {
+  return definition.kind === 'EnumTypeDefinition';
+}
+
+export function isGraphQLEnumExtension(definition: DefinitionNode): definition is EnumTypeExtensionNode {
+  return definition.kind === 'EnumTypeExtension';
+}
+
+export function isGraphQLUnion(definition: DefinitionNode): definition is UnionTypeDefinitionNode {
+  return definition.kind === 'UnionTypeDefinition';
+}
+
+export function isGraphQLUnionExtension(definition: DefinitionNode): definition is UnionTypeExtensionNode {
+  return definition.kind === 'UnionTypeExtension';
+}
+
+export function isGraphQLScalar(definition: DefinitionNode): definition is ScalarTypeDefinitionNode {
+  return definition.kind === 'ScalarTypeDefinition';
+}
+
+export function isGraphQLScalarExtension(definition: DefinitionNode): definition is ScalarTypeExtensionNode {
+  return definition.kind === 'ScalarTypeExtension';
+}
+
+export function isGraphQLInputType(definition: DefinitionNode): definition is InputObjectTypeDefinitionNode {
+  return definition.kind === 'InputObjectTypeDefinition';
+}
+
+export function isGraphQLInputTypeExtension(definition: DefinitionNode): definition is InputObjectTypeExtensionNode {
+  return definition.kind === 'InputObjectTypeExtension';
+}
+
+export function isGraphQLInterface(definition: DefinitionNode): definition is InterfaceTypeDefinitionNode {
+  return definition.kind === 'InterfaceTypeDefinition';
+}
+
+export function isGraphQLInterfaceExtension(definition: DefinitionNode): definition is InterfaceTypeExtensionNode {
+  return definition.kind === 'InterfaceTypeExtension';
+}
+
+export function isGraphQLDirective(definition: DefinitionNode): definition is DirectiveDefinitionNode {
+  return definition.kind === 'DirectiveDefinition';
+}
+
+export function isGraphQLSchema(obj: any): obj is GraphQLSchema {
+  return obj instanceof GraphQLSchema;
+}
+
+export function extractType(type: TypeNode): NamedTypeNode {
+
+  let visitedType = type;
+  while (visitedType.kind === 'ListType' || visitedType.kind === 'NonNullType') {
+    visitedType = visitedType.type;
+  }
+  return visitedType as any;
+
+}
+
+export function isSchemaDefinition(node: DefinitionNode): node is SchemaDefinitionNode {
+  return node.kind === 'SchemaDefinition';
+}

--- a/src/loaders/schema/schema-from-typedefs.ts
+++ b/src/loaders/schema/schema-from-typedefs.ts
@@ -1,4 +1,4 @@
-import { mergeGraphQLSchemas } from '../../epoxy';
+import { mergeTypeDefs } from '../../epoxy';
 import { SchemaLoader } from './schema-loader';
 import * as isGlob from 'is-glob';
 import * as isValidPath from 'is-valid-path';
@@ -71,6 +71,6 @@ export class SchemaFromTypedefs implements SchemaLoader {
       throw new Error(`All found files for glob expression "${globPath}" are not valid or empty, please check it and try again!`);
     }
 
-    return mergeGraphQLSchemas(filesContent.map(f => f.content));
+    return mergeTypeDefs(filesContent.map(f => f.content));
   }
 }

--- a/src/utils/extract-resolvers-from-schema.ts
+++ b/src/utils/extract-resolvers-from-schema.ts
@@ -6,11 +6,13 @@ export function extractResolversFromSchema(schema: GraphQLSchema): IResolvers {
     const resolvers: IResolvers = {};
     const typeMap = schema.getTypeMap();
     for (const typeName in typeMap) {
-        const typeDef = typeMap[typeName];
-        if (typeDef instanceof GraphQLScalarType) {
-            resolvers[typeName] = typeDef as GraphQLScalarType;
-        } else if (typeDef instanceof GraphQLObjectType || typeDef instanceof GraphQLInterfaceType) {
-            resolvers[typeName] = extractFieldResolversFromObjectType(typeDef);
+        if (!typeName.startsWith('__')){
+            const typeDef = typeMap[typeName];
+            if (typeDef instanceof GraphQLScalarType) {
+                resolvers[typeName] = typeDef as GraphQLScalarType;
+            } else if (typeDef instanceof GraphQLObjectType || typeDef instanceof GraphQLInterfaceType) {
+                resolvers[typeName] = extractFieldResolversFromObjectType(typeDef);
+            }
         }
     }
     return resolvers;

--- a/tests/epoxy/merge-schemas.spec.ts
+++ b/tests/epoxy/merge-schemas.spec.ts
@@ -1,0 +1,200 @@
+import { makeExecutableSchema } from "graphql-tools";
+import { mergeSchemas } from '../../src/epoxy';
+import gql from "graphql-tag";
+import { graphql } from "graphql";
+
+describe('Merge Schemas', async () => {
+    it('should merge two valid executable schemas', async () => {
+        const fooSchema = makeExecutableSchema({
+            typeDefs: gql`
+                type Query {
+                    foo: String
+                }
+            `,
+            resolvers: {
+                Query: {
+                    foo: () => 'FOO'
+                }
+            }
+        });
+        const barSchema = makeExecutableSchema({
+            typeDefs: gql`
+                type Query {
+                    bar: String
+                }
+            `,
+            resolvers: {
+                Query: {
+                    bar: () => 'BAR'
+                }
+            }
+        });
+        const { errors, data } = await graphql({
+            schema: mergeSchemas({
+                schemas: [fooSchema, barSchema]
+            }),
+            source: `
+                {
+                    foo
+                    bar
+                }
+            `
+        });
+        expect(errors).toBeFalsy();
+        expect(data.foo).toBe('FOO');
+        expect(data.bar).toBe('BAR');
+    });
+    it('should merge two valid executable schemas with extra resolvers', async () => {
+        const fooSchema = makeExecutableSchema({
+            typeDefs: gql`
+                type Query {
+                    foo: String
+                }
+            `,
+            resolvers: {
+                Query: {
+                    foo: () => 'FOO'
+                }
+            }
+        });
+        const barSchema = makeExecutableSchema({
+            typeDefs: gql`
+                type Query {
+                    bar: String
+                    qux: String
+                }
+            `,
+            resolvers: {
+                Query: {
+                    bar: () => 'BAR'
+                }
+            }
+        });
+        const { errors, data } = await graphql({
+            schema: mergeSchemas({
+                schemas: [fooSchema, barSchema],
+                resolvers: {
+                    Query: {
+                        qux: () => 'QUX'
+                    }
+                }
+            }),
+            source: `
+                {
+                    foo
+                    bar
+                    qux
+                }
+            `
+        });
+        expect(errors).toBeFalsy();
+        expect(data.foo).toBe('FOO');
+        expect(data.bar).toBe('BAR');
+        expect(data.qux).toBe('QUX');
+    });
+    it('should merge two valid executable schemas with extra typeDefs and resolvers', async () => {
+        const fooSchema = makeExecutableSchema({
+            typeDefs: gql`
+                type Query {
+                    foo: String
+                }
+            `,
+            resolvers: {
+                Query: {
+                    foo: () => 'FOO'
+                }
+            }
+        });
+        const barSchema = makeExecutableSchema({
+            typeDefs: gql`
+                type Query {
+                    bar: String
+                }
+            `,
+            resolvers: {
+                Query: {
+                    bar: () => 'BAR'
+                }
+            }
+        });
+        const { errors, data } = await graphql({
+            schema: mergeSchemas({
+                schemas: [fooSchema, barSchema],
+                typeDefs: gql`
+                    type Query {
+                        qux: String
+                    }
+                `,
+                resolvers: {
+                    Query: {
+                        qux: () => 'QUX'
+                    }
+                }
+            }),
+            source: `
+                {
+                    foo
+                    bar
+                    qux
+                }
+            `
+        });
+        expect(errors).toBeFalsy();
+        expect(data.foo).toBe('FOO');
+        expect(data.bar).toBe('BAR');
+        expect(data.qux).toBe('QUX');
+    });
+    it('should merge two valid schemas by keeping their directives to be used in extra typeDefs', async () => {
+        const fooSchema = makeExecutableSchema({
+            typeDefs: gql`
+                directive @fooDirective on FIELD_DEFINITION
+                type Query {
+                    foo: String
+                }
+            `,
+            resolvers: {
+                Query: {
+                    foo: () => 'FOO'
+                }
+            }
+        });
+        const barSchema = makeExecutableSchema({
+            typeDefs: gql`
+                type Query {
+                    bar: String
+                }
+            `,
+            resolvers: {
+                Query: {
+                    bar: () => 'BAR'
+                }
+            }
+        });
+        const { errors, data } = await graphql({
+            schema: mergeSchemas({
+                schemas: [fooSchema, barSchema],
+                typeDefs: gql`
+                    type Query {
+                        qux: String @fooDirective
+                    }
+                `,
+                resolvers: {
+                    Query: {
+                        qux: () => 'QUX'
+                    }
+                }
+            }),
+            source: `
+                {
+                    foo
+                    bar
+                    qux
+                }
+            `
+        });
+        expect(errors).toBeFalsy();
+        expect(data.foo).toBe('FOO');
+        expect(data.bar).toBe('BAR');
+        expect(data.qux).toBe('QUX');
+    });
+})

--- a/tests/epoxy/merge-typedefs.spec.ts
+++ b/tests/epoxy/merge-typedefs.spec.ts
@@ -1,11 +1,11 @@
-import { mergeGraphQLSchemas, mergeGraphQLTypes } from '../../src/epoxy/schema-mergers/merge-schema';
+import { mergeTypeDefs, mergeGraphQLTypes } from '../../src/epoxy/typedefs-mergers/merge-typedefs';
 import { makeExecutableSchema } from 'graphql-tools';
 import { buildSchema, buildClientSchema, print } from 'graphql';
 import { stripWhitespaces } from './utils';
 import gql from 'graphql-tag';
 import * as introspectionSchema from './schema.json';
 
-describe('Merge Schema', () => {
+describe('Merge TypeDefs', () => {
   describe('AST Schema Fixing', () => {
     it('Should handle correctly schema without valid root AST node', () => {
       const schema = buildSchema(`
@@ -77,7 +77,7 @@ describe('Merge Schema', () => {
     });
 
     it('should accept root schema object', () => {
-      const mergedSchema = mergeGraphQLSchemas([
+      const mergedSchema = mergeTypeDefs([
         'type RootQuery { f1: String }',
         'type RootQuery { f2: String }',
         'schema { query: RootQuery }',
@@ -113,9 +113,9 @@ describe('Merge Schema', () => {
     });
   });
 
-  describe('mergeGraphQLSchemas', () => {
+  describe('mergeTypeDefs', () => {
     it('should return a Document with the correct values', () => {
-      const merged = mergeGraphQLSchemas([
+      const merged = mergeTypeDefs([
         'type Query { f1: String }',
         'type Query { f2: String }',
         'type MyType { field: Int } type Query { f3: MyType }',
@@ -138,7 +138,7 @@ describe('Merge Schema', () => {
     });
 
     it('should skip printing schema definition object on session', () => {
-      const merged = mergeGraphQLSchemas([
+      const merged = mergeTypeDefs([
         'type Query { f1: String }',
         'type Query { f2: String }',
         'type MyType { field: Int } type Query { f3: MyType }',
@@ -163,7 +163,7 @@ describe('Merge Schema', () => {
     });
 
     it('should keep scalars', () => {
-      const mergedSchema = mergeGraphQLSchemas([
+      const mergedSchema = mergeTypeDefs([
         buildSchema('scalar UniqueId'),
       ]);
 
@@ -177,7 +177,7 @@ describe('Merge Schema', () => {
     });
 
     it('should merge descriptions', () => {
-      const merged = mergeGraphQLSchemas([
+      const merged = mergeTypeDefs([
         `
           " She's my type "
           type MyType { field1: Int }
@@ -210,7 +210,7 @@ describe('Merge Schema', () => {
     });
 
     it('should merge everything correctly', () => {
-      const merged = mergeGraphQLSchemas([
+      const merged = mergeTypeDefs([
         'type Query @test { f1: String }',
         'type Query @test2 { f2: String }',
         'type MyType { field: Int } type Query { f3: MyType } union MyUnion = MyType',
@@ -254,7 +254,7 @@ describe('Merge Schema', () => {
     });
 
     it('should include directives', () => {
-      const merged = mergeGraphQLSchemas([
+      const merged = mergeTypeDefs([
         `directive @id on FIELD_DEFINITION`,
         `type MyType { id: Int @id }`,
         `type Query { f1: MyType }`,
@@ -280,7 +280,7 @@ describe('Merge Schema', () => {
     });
 
     it('should append and extend directives', () => {
-      const merged = mergeGraphQLSchemas([
+      const merged = mergeTypeDefs([
         `directive @id(primitiveArg: String, arrayArg: [String]) on FIELD_DEFINITION`,
         `type MyType { id: Int }`,
         `type MyType { id: Int @id }`,
@@ -311,7 +311,7 @@ describe('Merge Schema', () => {
 
     it('should fail if inputs of the same directive are different from each other', (done: jest.DoneCallback) => {
       try {
-        mergeGraphQLSchemas([
+        mergeTypeDefs([
           `directive @id on FIELD_DEFINITION`,
           `directive @id(name: String) on FIELD_DEFINITION`,
           `type MyType { id: Int @id }`,
@@ -331,7 +331,7 @@ describe('Merge Schema', () => {
     });
 
     it('should merge the same directives', () => {
-      const merged = mergeGraphQLSchemas([
+      const merged = mergeTypeDefs([
         `directive @id on FIELD_DEFINITION`,
         `directive @id on FIELD_DEFINITION`,
         `type MyType { id: Int @id }`,
@@ -358,7 +358,7 @@ describe('Merge Schema', () => {
     });
 
     it('should merge two GraphQLSchema with directives correctly', () => {
-      const merged = mergeGraphQLSchemas([
+      const merged = mergeTypeDefs([
         makeExecutableSchema({
           typeDefs: [
             `type Query { f1: MyType }`,
@@ -377,7 +377,7 @@ describe('Merge Schema', () => {
     });
 
     it('should merge the same directives and its locations', () => {
-      const merged = mergeGraphQLSchemas([
+      const merged = mergeTypeDefs([
         `directive @id on FIELD_DEFINITION`,
         `directive @id on OBJECT`,
         `type MyType { id: Int @id }`,
@@ -406,7 +406,7 @@ describe('Merge Schema', () => {
 
   describe('input arguments', () => {
     it('should handle string correctly', () => {
-      const merged = mergeGraphQLSchemas([
+      const merged = mergeTypeDefs([
         'type Query { f1: String }',
       ]);
 
@@ -421,7 +421,7 @@ describe('Merge Schema', () => {
     });
 
     it('should handle compiled gql correctly', () => {
-      const merged = mergeGraphQLSchemas([
+      const merged = mergeTypeDefs([
         gql`
           type Query { f1: String }
         `,
@@ -438,7 +438,7 @@ describe('Merge Schema', () => {
     });
 
     it('should handle compiled gql and strings correctly', () => {
-      const merged = mergeGraphQLSchemas([
+      const merged = mergeTypeDefs([
         gql`
           type Query { f1: String }
         `,
@@ -457,7 +457,7 @@ describe('Merge Schema', () => {
     });
 
     it('should handle GraphQLSchema correctly', () => {
-      const merged = mergeGraphQLSchemas([
+      const merged = mergeTypeDefs([
         makeExecutableSchema({
           typeDefs: [
             'type Query { f1: String }',
@@ -479,7 +479,7 @@ describe('Merge Schema', () => {
     });
 
     it('should merge GraphQL Schemas that have schema definition', () => {
-      const merged = mergeGraphQLSchemas([
+      const merged = mergeTypeDefs([
         makeExecutableSchema({
           typeDefs: [
             'type RootQuery { f1: String }',
@@ -507,7 +507,7 @@ describe('Merge Schema', () => {
     });
 
     it('should handle all merged correctly', () => {
-      const merged = mergeGraphQLSchemas([
+      const merged = mergeTypeDefs([
         makeExecutableSchema({
           typeDefs: [
             'type Query { f1: String }',
@@ -533,7 +533,7 @@ describe('Merge Schema', () => {
     });
 
     it('should allow GraphQLSchema with empty Query', () => {
-      const merged = mergeGraphQLSchemas([
+      const merged = mergeTypeDefs([
         makeExecutableSchema({
           typeDefs: [
             'type MyType { f1: String }',
@@ -548,7 +548,7 @@ describe('Merge Schema', () => {
     });
 
     it('should allow GraphQLSchema with empty Query', () => {
-      const merged = mergeGraphQLSchemas([
+      const merged = mergeTypeDefs([
         makeExecutableSchema({
           typeDefs: [
             'type MyType { f1: String }',
@@ -568,7 +568,7 @@ describe('Merge Schema', () => {
         `));
     });
     it('should handle extend types', () => {
-      const merged = mergeGraphQLSchemas([`
+      const merged = mergeTypeDefs([`
         type Test {
           foo: String
         }
@@ -604,7 +604,7 @@ describe('Merge Schema', () => {
           }
         `],
       });
-      const merged = mergeGraphQLSchemas([schema]);
+      const merged = mergeTypeDefs([schema]);
       const printed = stripWhitespaces(print(merged));
 
       expect(printed).toContain(stripWhitespaces(`
@@ -623,7 +623,7 @@ describe('Merge Schema', () => {
 
     it('should fail when a field is already defined and has a different type', () => {
       expect(() => {
-        mergeGraphQLSchemas([`
+        mergeTypeDefs([`
           type Query {
             foo: String
           }
@@ -637,7 +637,7 @@ describe('Merge Schema', () => {
     });
 
     it('should preserve an extend keyword if there is no base', () => {
-      const merged = mergeGraphQLSchemas([`
+      const merged = mergeTypeDefs([`
         extend type Query {
           foo: String
         }
@@ -658,7 +658,7 @@ describe('Merge Schema', () => {
     });
 
     it('should handle extend inputs', () => {
-      const merged = mergeGraphQLSchemas([`
+      const merged = mergeTypeDefs([`
         input TestInput {
           foo: String
         }
@@ -675,7 +675,7 @@ describe('Merge Schema', () => {
       `));
     });
     it('should extend extension types', () => {
-      const merged = mergeGraphQLSchemas([`
+      const merged = mergeTypeDefs([`
         extend type Test {
           foo: String
         }
@@ -692,7 +692,7 @@ describe('Merge Schema', () => {
       `));
     });
     it('should extend extension input types', () => {
-      const merged = mergeGraphQLSchemas([`
+      const merged = mergeTypeDefs([`
         extend input TestInput {
           foo: String
         }


### PR DESCRIPTION
Introduce `mergeSchemas` with better features than `mergeSchemas` of `graphql-tools` such as keeping schema directives, adding required scalars etc.
Change `mergeGraphQLSchemas` to `mergeTypeDefs`