### PR TITLE
Allow treeshaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,17 +2,18 @@
   "name": "graphql-toolkit",
   "version": "0.0.5",
   "description": "A set of utils for faster development of GraphQL tools",
-  "main": "dist/index.js",
   "repository": "git@github.com:dotansimha/graphql-toolkit.git",
   "author": "Dotan Simha <dotansimha@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc -p tsconfig.es2015.json",
     "test": "jest",
     "prepare-release": "yarn build && yarn test",
     "release": "yarn prepare-release && npm publish",
     "ci:release:canary": "yarn prepare-release && node bump.js && npm publish --tag alpha"
   },
+  "main": "dist/index.js",
+  "module": "dist/es2015/index.js",
   "typings": "dist/index.d.ts",
   "typescript": {
     "definition": "dist/index.d.ts"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "is-valid-path": "0.1.1",
     "lodash": "4.17.11",
     "request": "2.88.0",
+    "tslib": "^1.9.3",
     "valid-url": "1.0.9"
   }
 }

--- a/src/loaders/documents/document-from-string.ts
+++ b/src/loaders/documents/document-from-string.ts
@@ -1,5 +1,5 @@
 import { DocumentLoader, DocumentFile } from './document-loader';
-import isValidPath = require('is-valid-path');
+import * as isValidPath from 'is-valid-path';
 import { parse } from 'graphql';
 
 export class DocumentFromString implements DocumentLoader {

--- a/tsconfig.es2015.json
+++ b/tsconfig.es2015.json
@@ -17,7 +17,8 @@
       "noImplicitReturns": true,
       "noUnusedLocals": true,
       "noUnusedParameters": true,
-      "resolveJsonModule": true
+      "resolveJsonModule": true,
+      "importHelpers": true
     },
     "include": ["src/**/*.ts"],
     "exclude": ["node_modules"]

--- a/tsconfig.es2015.json
+++ b/tsconfig.es2015.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+      "experimentalDecorators": true,
+      "module": "es2015",
+      "target": "es2018",
+      "lib": ["es6", "esnext", "es2015", "es2017.object"],
+      "suppressImplicitAnyIndexErrors": true,
+      "moduleResolution": "node",
+      "emitDecoratorMetadata": true,
+      "sourceMap": true,
+      "declaration": true,
+      "outDir": "./dist/es2015",
+      "rootDir": "./src/",
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "alwaysStrict": true,
+      "noImplicitReturns": true,
+      "noUnusedLocals": true,
+      "noUnusedParameters": true,
+      "resolveJsonModule": true
+    },
+    "include": ["src/**/*.ts"],
+    "exclude": ["node_modules"]
+  }
+  

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "experimentalDecorators": true,
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2018",
     "lib": ["es6", "esnext", "es2015", "es2017.object"],
     "suppressImplicitAnyIndexErrors": true,
     "moduleResolution": "node",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "importHelpers": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
- Add `es2015` bundle
- Change target to `es2018` because NodeJS already supports `es2018`, no need to transpile code.
- Use `tslib` to reduce the code