### PR TITLE
Allow to customize graphql-tag-pluck

### DIFF
--- a/src/loaders/documents/document-from-string.ts
+++ b/src/loaders/documents/document-from-string.ts
@@ -17,7 +17,7 @@ export class DocumentFromString implements DocumentLoader {
     }
   }
 
-  handle(doc: string): Promise<DocumentFile[]> | DocumentFile[] {
+  handle(doc: string, _options?: any): Promise<DocumentFile[]> | DocumentFile[] {
     return [{ filePath: 'document.graphql', content: parse(doc) }];
   }
 }

--- a/src/loaders/documents/document-loader.ts
+++ b/src/loaders/documents/document-loader.ts
@@ -5,7 +5,7 @@ export interface DocumentFile {
   content: DocumentNode;
 }
 
-export interface DocumentLoader {
+export interface DocumentLoader<TOptions = any> {
   canHandle(doc: string): Promise<boolean> | boolean;
-  handle(doc: string): Promise<DocumentFile[]> | DocumentFile[];
+  handle(doc: string, options?: TOptions): Promise<DocumentFile[]> | DocumentFile[];
 }

--- a/src/loaders/documents/index.ts
+++ b/src/loaders/documents/index.ts
@@ -6,10 +6,10 @@ export { DocumentFromString } from './document-from-string';
 export { DocumentsFromGlob } from './documents-from-glob';
 export { DocumentLoader, DocumentFile } from './document-loader';
 
-export const loadDocuments = async (documentDef: string, documentsHandlers = [new DocumentFromString(), new DocumentsFromGlob()]): Promise<DocumentFile[]> => {
+export const loadDocuments = async (documentDef: string, options: any, documentsHandlers = [new DocumentFromString(), new DocumentsFromGlob()]): Promise<DocumentFile[]> => {
   for (const handler of documentsHandlers) {
     if (await handler.canHandle(documentDef)) {
-      return handler.handle(documentDef);
+      return handler.handle(documentDef, options);
     }
   }
 

--- a/src/loaders/documents/index.ts
+++ b/src/loaders/documents/index.ts
@@ -6,7 +6,7 @@ export { DocumentFromString } from './document-from-string';
 export { DocumentsFromGlob } from './documents-from-glob';
 export { DocumentLoader, DocumentFile } from './document-loader';
 
-export const loadDocuments = async (documentDef: string, options: any, documentsHandlers = [new DocumentFromString(), new DocumentsFromGlob()]): Promise<DocumentFile[]> => {
+export const loadDocuments = async (documentDef: string, options: any = {}, documentsHandlers = [new DocumentFromString(), new DocumentsFromGlob()]): Promise<DocumentFile[]> => {
   for (const handler of documentsHandlers) {
     if (await handler.canHandle(documentDef)) {
       return handler.handle(documentDef, options);

--- a/src/loaders/schema/index.ts
+++ b/src/loaders/schema/index.ts
@@ -13,7 +13,7 @@ export { SchemaFromExport } from './schema-from-export';
 
 export const loadSchema = async <T = any>(
   pointToSchema: string,
-  options: T,
+  options?: T,
   schemaHandlers = [new IntrospectionFromUrlLoader(), new IntrospectionFromFileLoader(), new SchemaFromString(), new SchemaFromTypedefs(), new SchemaFromExport()]
 ): Promise<GraphQLSchema | DocumentNode> => {
   for (const handler of schemaHandlers) {

--- a/src/loaders/schema/introspection-from-file.ts
+++ b/src/loaders/schema/introspection-from-file.ts
@@ -25,7 +25,7 @@ export class IntrospectionFromFileLoader implements SchemaLoader {
     return isValidPath(pointerToSchema) && existsSync(pointerToSchema) && extname(pointerToSchema) === '.json';
   }
 
-  handle(pointerToSchema: string): Promise<GraphQLSchema> {
+  handle(pointerToSchema: string, _options?: any): Promise<GraphQLSchema> {
     return new Promise<GraphQLSchema>((resolve, reject) => {
       const fullPath = isAbsolute(pointerToSchema) ? pointerToSchema : resolvePath(process.cwd(), pointerToSchema);
 

--- a/src/loaders/schema/schema-from-export.ts
+++ b/src/loaders/schema/schema-from-export.ts
@@ -11,7 +11,7 @@ export class SchemaFromExport implements SchemaLoader {
     return isValidPath(pointerToSchema) && existsSync(fullPath) && extname(pointerToSchema) !== '.json';
   }
 
-  async handle(file: string): Promise<GraphQLSchema> {
+  async handle(file: string, _options?: any): Promise<GraphQLSchema> {
     const fullPath = isAbsolute(file) ? file : resolvePath(process.cwd(), file);
 
     if (existsSync(fullPath)) {

--- a/src/loaders/schema/schema-from-string.ts
+++ b/src/loaders/schema/schema-from-string.ts
@@ -21,7 +21,7 @@ export class SchemaFromString implements SchemaLoader {
     }
   }
 
-  handle(str: string): DocumentNode {
+  handle(str: string, _options?: any): DocumentNode {
     return parse(str);
   }
 }

--- a/src/loaders/schema/schema-from-typedefs.ts
+++ b/src/loaders/schema/schema-from-typedefs.ts
@@ -30,7 +30,9 @@ function loadSchemaFile(filepath: string, options?: ExtractOptions): string {
       return foundDoc;
     }
 
-    return content;
+    if (isGraphQLFile(filepath)) {
+      return content;
+    }
   } else {
     console['warn'](`Empty schema file found: "${filepath}", skipping...`);
   }

--- a/src/utils/extract-document-string-from-code-file.ts
+++ b/src/utils/extract-document-string-from-code-file.ts
@@ -1,7 +1,47 @@
 import { Source, parse } from 'graphql';
 import gqlPluck from 'graphql-tag-pluck';
 
-export function extractDocumentStringFromCodeFile(source: Source): string | void {
+export interface ExtractOptions {
+  tagPluck?: {
+    modules?: Array<{ name: string; identifier?: string }>;
+    magicComment?: string;
+    globalIdentifier?: string;
+  };
+}
+
+interface GraphQLTagPluckOptions {
+  modules?: Array<{ name: string; identifier?: string }>;
+  gqlMagicComment?: string;
+  globalGqlIdentifierName?: string;
+}
+
+function calculateOptions(options?: ExtractOptions) {
+  if (!options || !options.tagPluck) {
+    return {};
+  }
+
+  // toolkit option's key -> option in graphql-tag-pluck
+  const keyMap = {
+    modules: 'modules',
+    magicComment: 'gqlMagicComment',
+    globalIdentifier: 'globalGqlIdentifierName',
+  };
+
+  return Object.keys(keyMap).reduce<GraphQLTagPluckOptions>((prev, curr) => {
+    const value = options.tagPluck[curr];
+
+    if (value) {
+      return {
+        ...prev,
+        [keyMap[curr]]: value,
+      };
+    }
+
+    return prev;
+  }, {});
+}
+
+export function extractDocumentStringFromCodeFile(source: Source, options?: ExtractOptions): string | void {
   try {
     const parsed = parse(source.body);
 
@@ -10,7 +50,7 @@ export function extractDocumentStringFromCodeFile(source: Source): string | void
     }
   } catch (e) {
     try {
-      return gqlPluck.fromFile.sync(source.name) || null;
+      return gqlPluck.fromFile.sync(source.name, calculateOptions(options)) || null;
     } catch (e) {
       throw new e.constructor(`${e.message} at ${source.name}`);
     }

--- a/tests/loaders/documents/documents-from-glob.spec.ts
+++ b/tests/loaders/documents/documents-from-glob.spec.ts
@@ -1,4 +1,5 @@
 import { join } from 'path';
+import { separateOperations } from 'graphql';
 import { DocumentsFromGlob } from '../../../src/loaders/documents/documents-from-glob';
 
 describe('documentsFromGlob', () => {
@@ -21,6 +22,46 @@ describe('documentsFromGlob', () => {
     expect(result.length).toBe(2);
     expect(result[0].content).toBeDefined();
     expect(result[1].content).toBeDefined();
+  });
+
+  it('Should load two GraphQL documents both for gatsby and graphql-tag by default', async () => {
+    const glob = join(__dirname, './test-files/', 'tags.js');
+    const handler = new DocumentsFromGlob();
+    const canHandle = handler.canHandle(glob);
+
+    // should handle
+    expect(canHandle).toEqual(true);
+
+    // should get documents
+    const result = await handler.handle(glob);
+    const operations = separateOperations(result[0].content);
+
+    expect(Object.keys(operations)).toHaveLength(2);
+  });
+
+  it('Should load GraphQL documents that match custom settings', async () => {
+    const glob = join(__dirname, './test-files/', 'tags.js');
+    const handler = new DocumentsFromGlob();
+    const canHandle = handler.canHandle(glob);
+
+    // should handle
+    expect(canHandle).toEqual(true);
+
+    // should get documents
+    const result = await handler.handle(glob, {
+      tagPluck: {
+        modules: [
+          {
+            name: 'parse-graphql',
+            identifier: 'parse',
+          },
+        ],
+      },
+    });
+
+    const operations = separateOperations(result[0].content);
+
+    expect(Object.keys(operations)).toHaveLength(1);
   });
 
   it('Should ignore empty files', async () => {

--- a/tests/loaders/documents/test-files/tags.js
+++ b/tests/loaders/documents/test-files/tags.js
@@ -1,0 +1,21 @@
+import gql from 'graphql-tag';
+import { graphql } from 'gatsby';
+import { parse } from 'parse-graphql';
+
+export const aQuery = gql`
+  query a {
+    a
+  }
+`;
+
+export const bQuery = graphql`
+  query b {
+    b
+  }
+`;
+
+export const cQuery = parse`
+  query c {
+    c
+  }
+`;

--- a/tests/loaders/schema/integration.spec.ts
+++ b/tests/loaders/schema/integration.spec.ts
@@ -1,7 +1,7 @@
 import { buildASTSchema, isSchema, GraphQLSchema } from 'graphql';
 import { loadSchema } from '../../../src';
 
-it('should work with graphql-tag and gatsby by default', async () => {
+it('should work with graphql-tag and gatsby by default and not throw on files without those parsers', async () => {
   const schemaPath = './tests/loaders/schema/test-files/schema-dir/type-defs/*.ts';
   const built = await loadSchema(schemaPath);
   let schema: GraphQLSchema;

--- a/tests/loaders/schema/integration.spec.ts
+++ b/tests/loaders/schema/integration.spec.ts
@@ -1,0 +1,15 @@
+import { buildASTSchema, isSchema, GraphQLSchema } from 'graphql';
+import { loadSchema } from '../../../src';
+
+it('should work with graphql-tag and gatsby by default', async () => {
+  const schemaPath = './tests/loaders/schema/test-files/schema-dir/type-defs/*.ts';
+  const built = await loadSchema(schemaPath);
+  let schema: GraphQLSchema;
+
+  if (!isSchema(built)) {
+    schema = buildASTSchema(built);
+  }
+
+  expect(schema.getTypeMap()['User']).toBeDefined();
+  expect(schema.getTypeMap()['Query']).toBeDefined();
+});

--- a/tests/loaders/schema/test-files/schema-dir/type-defs/custom.ts
+++ b/tests/loaders/schema/test-files/schema-dir/type-defs/custom.ts
@@ -1,0 +1,11 @@
+import { parser } from 'custom-graphql-parser';
+
+export const typeDefs = parser`
+  type Query {
+    book: Book
+  }
+
+  type Book {
+    a: String
+  }
+`;

--- a/tests/loaders/schema/test-files/schema-dir/type-defs/gatsby.ts
+++ b/tests/loaders/schema/test-files/schema-dir/type-defs/gatsby.ts
@@ -1,0 +1,7 @@
+import { graphql } from 'gatsby';
+
+export const typeDefs = graphql`
+  extend type User {
+    b: String
+  }
+`;

--- a/tests/loaders/schema/test-files/schema-dir/type-defs/graphql-tag.ts
+++ b/tests/loaders/schema/test-files/schema-dir/type-defs/graphql-tag.ts
@@ -1,0 +1,11 @@
+import gql from 'graphql-tag';
+
+export const typeDefs = gql`
+  type Query {
+    user: User
+  }
+
+  type User {
+    a: String
+  }
+`;


### PR DESCRIPTION
We need to in graphql-code-generator to allow users to define their own settings.

**It's a breaking change** because I changed the order of `loadDocuments` arguments (those should be turned into key-value object).