### PR TITLE
Allow glob patterns in schema-from-export

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,11 +44,12 @@
   },
   "dependencies": {
     "aggregate-error": "2.2.0",
+    "asyncro": "^3.0.0",
     "deepmerge": "3.2.0",
     "glob": "7.1.3",
     "graphql-import": "0.7.1",
-    "graphql-tools": "4.0.4",
     "graphql-tag-pluck": "0.8.0",
+    "graphql-tools": "4.0.4",
     "is-glob": "4.0.0",
     "is-valid-path": "0.1.1",
     "lodash": "4.17.11",

--- a/src/loaders/schema/schema-from-export.ts
+++ b/src/loaders/schema/schema-from-export.ts
@@ -4,48 +4,80 @@ import * as isValidPath from 'is-valid-path';
 import { buildASTSchema, buildClientSchema, DocumentNode, GraphQLSchema, IntrospectionQuery, parse } from 'graphql';
 import { SchemaLoader } from './schema-loader';
 import { isGraphQLFile } from './schema-from-typedefs';
+import * as isGlob from 'is-glob';
+import { sync as globSync } from 'glob';
+import { mergeTypeDefs } from '../../epoxy';
+import { filter } from 'asyncro';
 
 export class SchemaFromExport implements SchemaLoader {
-  async canHandle(pointerToSchema: string): Promise<boolean> {
-    const fullPath = isAbsolute(pointerToSchema) ? pointerToSchema : resolvePath(process.cwd(), pointerToSchema);
+  static getFiles(globOrValidPath: string): string[] {
+    return (isGlob(globOrValidPath) ? globSync(globOrValidPath, {
+      absolute: true,
+      cwd: process.cwd(),
+    }) : [globOrValidPath])
+      .filter(file => !file.includes('node_modules') && !file.endsWith('.d.ts') && !file.endsWith('.spec.ts'));
+  }
+  async canHandle(globOrValidPath: string): Promise<boolean> {
+    const files = SchemaFromExport.getFiles(globOrValidPath);
 
-    if (isValidPath(pointerToSchema) && existsSync(fullPath) && extname(pointerToSchema) !== '.json' && !isGraphQLFile(fullPath)) {
-      const exports = await import(fullPath);
-      const schema = exports.default || exports.schema || exports;
+    for (let file of files) {
+      try {
+        const fullPath = isAbsolute(file) ? file : resolvePath(process.cwd(), file);
 
-      return this.isSchemaObject(schema) || this.isSchemaAst(schema) || this.isSchemaText(schema) ||
-        this.isWrappedSchemaJson(schema) || this.isSchemaJson(schema);
-    } else {
-      return false;
+        if (isValidPath(file) && existsSync(fullPath) && extname(file) !== '.json' && !isGraphQLFile(fullPath)) {
+          const exports = await import(fullPath);
+          const schema = await (exports.default || exports.schema || exports);
+
+          if (this.isSchemaObject(schema) || this.isSchemaAst(schema) || this.isSchemaText(schema) ||
+            this.isWrappedSchemaJson(schema) || this.isSchemaJson(schema)) {
+            return true;
+          }
+        }
+      } catch (err) {}
     }
+    return false;
   }
 
-  async handle(file: string, _options?: any): Promise<GraphQLSchema> {
-    const fullPath = isAbsolute(file) ? file : resolvePath(process.cwd(), file);
+  async handle(globOrValidPath: string, _options?: any): Promise<GraphQLSchema> {
+    const files = SchemaFromExport.getFiles(globOrValidPath);
 
-    if (existsSync(fullPath)) {
-      const exports = await import(fullPath);
+    const filtered = await filter(files, async file => await this.canHandle(file));
 
-      if (exports) {
-        let rawExport = exports.default || exports.schema || exports;
+    const schemas = await Promise.all(filtered.map(async file => {
+      const fullPath = isAbsolute(file) ? file : resolvePath(process.cwd(), file);
 
-        if (rawExport) {
-          let schema = await rawExport;
-          schema = await (schema.default || schema.schema || schema);
-          try {
-            return await this.resolveSchema(schema);
-          } catch (e) {
-            throw new Error('Exported schema must be of type GraphQLSchema, text, AST, or introspection JSON.');
+      if (existsSync(fullPath)) {
+        const exports = await import(fullPath);
+
+        if (exports) {
+          let rawExport = exports.default || exports.schema || exports;
+
+          if (rawExport) {
+            let schema = await rawExport;
+            schema = await (schema.default || schema.schema || schema);
+            try {
+              return await this.resolveSchema(schema);
+            } catch (e) {
+              throw new Error('Exported schema must be of type GraphQLSchema, text, AST, or introspection JSON.');
+            }
+          } else {
+            throw new Error(`Invalid export from export file ${fullPath}: missing default export or 'schema' export!`);
           }
         } else {
-          throw new Error(`Invalid export from export file ${fullPath}: missing default export or 'schema' export!`);
+          throw new Error(`Invalid export from export file ${fullPath}: empty export!`);
         }
       } else {
-        throw new Error(`Invalid export from export file ${fullPath}: empty export!`);
+        throw new Error(`Unable to locate introspection from export file: ${fullPath}`);
       }
-    } else {
-      throw new Error(`Unable to locate introspection from export file: ${fullPath}`);
+    }));
+
+    if (schemas.length === 1) {
+      return schemas[0];
     }
+
+    const node = mergeTypeDefs(schemas);
+
+    return buildASTSchema(node);
   }
 
   isSchemaText(obj: any): obj is string {
@@ -79,8 +111,6 @@ export class SchemaFromExport implements SchemaLoader {
   async resolveSchema(schema: GraphQLSchema | DocumentNode | string | { data: IntrospectionQuery } | IntrospectionQuery) {
     if (this.isSchemaObject(schema)) {
       return schema;
-    } else if (this.isSchemaAst(schema)) {
-      return buildASTSchema(schema);
     } else if (this.isSchemaText(schema)) {
       const ast = parse(schema);
       return buildASTSchema(ast);
@@ -88,6 +118,8 @@ export class SchemaFromExport implements SchemaLoader {
       return buildClientSchema(schema.data);
     } else if (this.isSchemaJson(schema)) {
       return buildClientSchema(schema);
+    } else if (this.isSchemaAst(schema)) {
+      return buildASTSchema(schema);
     } else {
       throw new Error('Unexpected schema type provided!');
     }

--- a/tests/loaders/schema/schema-from-export.spec.ts
+++ b/tests/loaders/schema/schema-from-export.spec.ts
@@ -23,4 +23,12 @@ describe('Schema From Export', () => {
     const result: any = await instance.handle('./tests/loaders/schema/test-files/loaders/promise-export.js');
     expect(result instanceof GraphQLSchema).toBeTruthy();
   });
+
+  it('should work with glob patterns', async () => {
+    const schemaPath = './tests/loaders/schema/test-files/loaders/*.js';
+    const canHandle = await instance.canHandle(schemaPath);
+    expect(canHandle).toBeTruthy();
+    const schema = await instance.handle(schemaPath);
+    expect(schema instanceof GraphQLSchema).toBeTruthy();
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,12 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "resolveJsonModule": true,
-    "importHelpers": true
+    "importHelpers": true,
+    "typeRoots": [ "./types", "./node_modules/@types"],
+    "baseUrl": ".",
+    "paths": {
+      "*": ["./types/*"]
+    }
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/types/asyncro.d.ts
+++ b/types/asyncro.d.ts
@@ -1,0 +1,294 @@
+declare module 'asyncro' {
+  type AsyncFn<T> = () => PromiseLike<T>;
+  type AsyncFnReturnType<T> = T extends AsyncFn<infer U> ? U : any;
+
+  interface Asyncro {
+    /**
+     * Invoke an async reducer function on each item in the given Array,
+     * where the reducer transforms an accumulator value based on each item
+     * iterated over.
+     * **Note**: because reduce() is order-sensitive, iteration is sequential.
+     * > This is an asynchronous version of Array.prototype.reduce().
+     * @param array The Array to reduce.
+     * @param reducer Async function, gets passed (accumulator, value, index,
+     * array) and returns a new value for accumulator.
+     * @param accumulator Optional initial accumulator value.
+     * @returns Any final accumulator value.
+     */
+    reduce<T>(
+      array: ArrayLike<T>,
+      reducer: (
+        accumulator: T,
+        value: T,
+        index: number,
+        array: ArrayLike<T>,
+      ) => PromiseLike<T>,
+      accumulator?: T,
+    ): T;
+    reduce<T, U>(
+      array: ArrayLike<T>,
+      reducer: (
+        accumulator: U,
+        value: T,
+        index: number,
+        array: ArrayLike<T>,
+      ) => PromiseLike<U>,
+      accumulator: U,
+    ): Promise<U>;
+
+    /**
+     * Invoke an async transform function on each item in the given Array in
+     * parallel, returning the resulting Array of mapped/transformed items.
+     * @param array Invoke an async transform function on each item in the
+     * given Array in parallel, returning the resulting Array of
+     * mapped/transformed items.
+     * > This is an asynchronous, parallelized version of Array.prototype.map().
+     * @param mapper Async function, gets passed (value, index, array),
+     * returns the new value.
+     * @returns Array resulting mapped/transformed values.
+     */
+    map<T, U>(
+      array: ArrayLike<T>,
+      mapper: (value: T, index: number, array: ArrayLike<T>) => PromiseLike<U>,
+    ): Promise<U[]>;
+
+    /**
+     * Invoke an async filter function on each item in the given Array in
+     * parallel, returning an Array of values for which the filter function
+     * returned a truthy value.
+     * > This is an asynchronous, parallelized version of Array.prototype.filter().
+     * @param array The Array to filter.
+     * @param filterer Async function. Gets passed (value, index, array),
+     * returns true to keep the value in the resulting filtered Array.
+     * @returns Array resulting filtered values.
+     */
+    filter<T>(
+      array: ArrayLike<T>,
+      filterer: (value: T, index: number, array: T[]) => PromiseLike<any>,
+    ): Promise<T[]>;
+    /**
+     * Invoke an async function on each item in the given Array in parallel,
+     * returning the first element predicate returns truthy for.
+     * > This is an asynchronous, parallelized version of
+     * Array.prototype.find().
+     * @param array The Array to find.
+     * @param predicate Async function. Gets passed (value, index, array), returns true
+     * to be the find result.
+     * @returns Any resulting find value.
+     */
+    find<T>(
+      array: ArrayLike<T>,
+      predicate: (value: T, index: number, array: T[]) => PromiseLike<boolean>,
+    ): Promise<T | undefined>;
+
+    /**
+     * Checks if predicate returns truthy for all elements of collection in
+     * parallel.
+     * > This is an asynchronous, parallelized version of
+     * Array.prototype.every().
+     * @param array The Array to iterate over.
+     * @param predicate Async function. Gets passed (value, index, array), The
+     * function invoked per iteration.
+     * @returns Returns true if all element passes the predicate check, else
+     * false.
+     */
+    every<T>(
+      array: ArrayLike<T>,
+      predicate: (value: T, index: number, array: T[]) => PromiseLike<boolean>,
+    ): boolean;
+
+    /**
+     * Checks if predicate returns truthy for any element of collection in
+     * parallel.
+     * @param array The Array to iterate over.
+     * @param predicate Async function. Gets passed (value, index, array), The
+     * function invoked per iteration.
+     * @returns Returns true if any element passes the predicate check, else
+     * false.
+     */
+    some<T>(
+      array: ArrayLike<T>,
+      predicate: (value: T, index: number, array: T[]) => PromiseLike<boolean>,
+    ): boolean;
+
+    /**
+     * Invoke all async functions in an Object in parallel, returning the
+     * result.
+     * @param list Object with values that are async functions to invoke.
+     * @returns Same structure as list input, but with values now resolved.
+     */
+    parallel<T extends Record<string, AsyncFn<any>>>(
+      list: T,
+    ): Promise<{[K in keyof T]: AsyncFnReturnType<T[K]>}>;
+
+    /**
+     * Invoke all async functions in an Array in parallel, returning the
+     * result.
+     * @param list Array with values that are async functions to invoke.
+     * @returns Same structure as list input, but with values now resolved.
+     */
+    parallel<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+      list: [
+        AsyncFn<T1>,
+        AsyncFn<T2>,
+        AsyncFn<T3>,
+        AsyncFn<T4>,
+        AsyncFn<T5>,
+        AsyncFn<T6>,
+        AsyncFn<T7>,
+        AsyncFn<T8>,
+        AsyncFn<T9>,
+        AsyncFn<T10>
+        ],
+    ): Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]>;
+    parallel<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+      list: [
+        AsyncFn<T1>,
+        AsyncFn<T2>,
+        AsyncFn<T3>,
+        AsyncFn<T4>,
+        AsyncFn<T5>,
+        AsyncFn<T6>,
+        AsyncFn<T7>,
+        AsyncFn<T8>,
+        AsyncFn<T9>
+        ],
+    ): Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9]>;
+    parallel<T1, T2, T3, T4, T5, T6, T7, T8>(
+      list: [
+        AsyncFn<T1>,
+        AsyncFn<T2>,
+        AsyncFn<T3>,
+        AsyncFn<T4>,
+        AsyncFn<T5>,
+        AsyncFn<T6>,
+        AsyncFn<T7>,
+        AsyncFn<T8>
+        ],
+    ): Promise<[T1, T2, T3, T4, T5, T6, T7, T8]>;
+    parallel<T1, T2, T3, T4, T5, T6, T7>(
+      list: [
+        AsyncFn<T1>,
+        AsyncFn<T2>,
+        AsyncFn<T3>,
+        AsyncFn<T4>,
+        AsyncFn<T5>,
+        AsyncFn<T6>,
+        AsyncFn<T7>
+        ],
+    ): Promise<[T1, T2, T3, T4, T5, T6, T7]>;
+    parallel<T1, T2, T3, T4, T5, T6>(
+      list: [
+        AsyncFn<T1>,
+        AsyncFn<T2>,
+        AsyncFn<T3>,
+        AsyncFn<T4>,
+        AsyncFn<T5>,
+        AsyncFn<T6>
+        ],
+    ): Promise<[T1, T2, T3, T4, T5, T6]>;
+    parallel<T1, T2, T3, T4, T5>(
+      list: [AsyncFn<T1>, AsyncFn<T2>, AsyncFn<T3>, AsyncFn<T4>, AsyncFn<T5>],
+    ): Promise<[T1, T2, T3, T4, T5]>;
+    parallel<T1, T2, T3, T4>(
+      list: [AsyncFn<T1>, AsyncFn<T2>, AsyncFn<T3>, AsyncFn<T4>],
+    ): Promise<[T1, T2, T3]>;
+    parallel<T1, T2, T3>(
+      list: [AsyncFn<T1>, AsyncFn<T2>, AsyncFn<T3>],
+    ): Promise<[T1, T2, T3]>;
+    parallel<T1, T2>(list: [AsyncFn<T1>, AsyncFn<T2>]): Promise<[T1, T2]>;
+    parallel<T>(list: ArrayLike<AsyncFn<T>>): Promise<T[]>;
+
+    /**
+     * Invoke all async functions in an Object sequentially, returning the
+     * result.
+     * @param list Object with values that are async functions to invoke.
+     * @returns Same structure as list input, but with values now resolved.
+     */
+    series<T extends Record<string, AsyncFn<any>>>(
+      list: T,
+    ): Promise<{[K in keyof T]: AsyncFnReturnType<T[K]>}>;
+
+    /**
+     * Invoke all async functions in an Array sequentially, returning the
+     * result.
+     * @param list Array with values that are async functions to invoke.
+     * @returns Same structure as list input, but with values now resolved.
+     */
+    series<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+      list: [
+        AsyncFn<T1>,
+        AsyncFn<T2>,
+        AsyncFn<T3>,
+        AsyncFn<T4>,
+        AsyncFn<T5>,
+        AsyncFn<T6>,
+        AsyncFn<T7>,
+        AsyncFn<T8>,
+        AsyncFn<T9>,
+        AsyncFn<T10>
+        ],
+    ): Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]>;
+    series<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+      list: [
+        AsyncFn<T1>,
+        AsyncFn<T2>,
+        AsyncFn<T3>,
+        AsyncFn<T4>,
+        AsyncFn<T5>,
+        AsyncFn<T6>,
+        AsyncFn<T7>,
+        AsyncFn<T8>,
+        AsyncFn<T9>
+        ],
+    ): Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9]>;
+    series<T1, T2, T3, T4, T5, T6, T7, T8>(
+      list: [
+        AsyncFn<T1>,
+        AsyncFn<T2>,
+        AsyncFn<T3>,
+        AsyncFn<T4>,
+        AsyncFn<T5>,
+        AsyncFn<T6>,
+        AsyncFn<T7>,
+        AsyncFn<T8>
+        ],
+    ): Promise<[T1, T2, T3, T4, T5, T6, T7, T8]>;
+    series<T1, T2, T3, T4, T5, T6, T7>(
+      list: [
+        AsyncFn<T1>,
+        AsyncFn<T2>,
+        AsyncFn<T3>,
+        AsyncFn<T4>,
+        AsyncFn<T5>,
+        AsyncFn<T6>,
+        AsyncFn<T7>
+        ],
+    ): Promise<[T1, T2, T3, T4, T5, T6, T7]>;
+    series<T1, T2, T3, T4, T5, T6>(
+      list: [
+        AsyncFn<T1>,
+        AsyncFn<T2>,
+        AsyncFn<T3>,
+        AsyncFn<T4>,
+        AsyncFn<T5>,
+        AsyncFn<T6>
+        ],
+    ): Promise<[T1, T2, T3, T4, T5, T6]>;
+    series<T1, T2, T3, T4, T5>(
+      list: [AsyncFn<T1>, AsyncFn<T2>, AsyncFn<T3>, AsyncFn<T4>, AsyncFn<T5>],
+    ): Promise<[T1, T2, T3, T4, T5]>;
+    series<T1, T2, T3, T4>(
+      list: [AsyncFn<T1>, AsyncFn<T2>, AsyncFn<T3>, AsyncFn<T4>],
+    ): Promise<[T1, T2, T3]>;
+    series<T1, T2, T3>(
+      list: [AsyncFn<T1>, AsyncFn<T2>, AsyncFn<T3>],
+    ): Promise<[T1, T2, T3]>;
+    series<T1, T2>(list: [AsyncFn<T1>, AsyncFn<T2>]): Promise<[T1, T2]>;
+    series<T>(list: ArrayLike<AsyncFn<T>>): Promise<T[]>;
+  }
+
+  const Asyncro: Asyncro;
+
+  export = Asyncro;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -609,6 +609,11 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
+asyncro@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/asyncro/-/asyncro-3.0.0.tgz#3c7a732e263bc4a42499042f48d7d858e9c0134e"
+  integrity sha512-nEnWYfrBmA3taTiuiOoZYmgJ/CNrSoQLeLs29SeLcPu60yaw/mHDBHV0iOZ051fTvsTHxpCY+gXibqT9wbQYfg==
+
 atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"


### PR DESCRIPTION
I'm using `asyncro` to add async array methods like filter and reduce.
Typings for asyncro are still not shipped with the library, so I took them from this PR: https://github.com/developit/asyncro/pull/10