### PR TITLE
Correctly catch async `gqlPluckFromFile` Errors

### DIFF
--- a/src/utils/extract-document-string-from-code-file.ts
+++ b/src/utils/extract-document-string-from-code-file.ts
@@ -50,7 +50,7 @@ export async function extractDocumentStringFromCodeFile(source: Source, options?
   } catch (e) {
     try {
       const { gqlPluckFromFile } = eval(`require('graphql-tag-pluck')`);
-      return gqlPluckFromFile(source.name, calculateOptions(options)) || null;
+      return (await gqlPluckFromFile(source.name, calculateOptions(options))) || null;
     } catch (e) {
       throw new e.constructor(`${e.message} at ${source.name}`);
     }


### PR DESCRIPTION
try/catch is sadly broken inside of async functions when you `return` a `Promise`.

Before: `SyntaxError: Export 'Context' is not defined (6:9)`
After: `SyntaxError: Export 'Context' is not defined (6:9) at […]/localization/react.d.ts`

Found this while trying to debug a really strange failure with `graphql-code-generator`…