### PR TITLE
fixed loadSchema so that it uses DEFAULT_SCHEMA_LOADERS

### DIFF
--- a/packages/graphql-toolkit/src/index.ts
+++ b/packages/graphql-toolkit/src/index.ts
@@ -28,6 +28,6 @@ export async function loadDocuments(pointerOrPointers: string | string[], option
   return loadDocumentsUsingLoaders(loaders, pointerOrPointers, options, cwd);
 }
 
-export async function loadSchema(pointerOrPointers: string | string[], options: LoadTypedefsOptions<CodeFileLoaderOptions | GraphQLFileLoaderOptions> = {}, cwd = process.cwd(), loaders: Loader[] = DEFAULT_DOCUMENTS_LOADERS): Promise<GraphQLSchema> {
+export async function loadSchema(pointerOrPointers: string | string[], options: LoadTypedefsOptions<CodeFileLoaderOptions | GraphQLFileLoaderOptions> = {}, cwd = process.cwd(), loaders: Loader[] = DEFAULT_SCHEMA_LOADERS): Promise<GraphQLSchema> {
   return loadSchemaUsingLoaders(loaders, pointerOrPointers, options, cwd);
 }


### PR DESCRIPTION
Tried to use it but the example failed when trying to read from an URL.
This fixes it.