### PR TITLE
Add support for `.vue` files to code-file loader

### DIFF
--- a/packages/graphql-tag-pluck/package.json
+++ b/packages/graphql-tag-pluck/package.json
@@ -43,5 +43,8 @@
   "publishConfig": {
     "access": "public",
     "directory": "dist"
+  },
+  "optionalDependencies": {
+    "vue-template-compiler": "^2.6.10"
   }
 }

--- a/packages/graphql-tag-pluck/src/index.ts
+++ b/packages/graphql-tag-pluck/src/index.ts
@@ -15,13 +15,21 @@ export interface GraphQLTagPluckOptions {
 
 const gqlExtensions = ['.graphqls', '.graphql', '.gqls', '.gql'];
 
-const jsExtensions = ['.js', '.jsx', '.ts', '.tsx', '.flow', '.flow.js', '.flow.jsx'];
+const jsExtensions = ['.js', '.jsx', '.ts', '.tsx', '.flow', '.flow.js', '.flow.jsx', '.vue'];
 
 const supportedExtensions = [...gqlExtensions, ...jsExtensions];
 
 supportedExtensions.toString = function toString() {
   return this.join(', ');
 };
+
+function pluckVueFileScript(fileData): string {
+  const compiler = require('vue-template-compiler');
+  const parsed = compiler.parseComponent(fileData);
+  const script: string = parsed.script ? parsed.script.content : '';
+
+  return script;
+}
 
 export const gqlPluckFromFile = async (filePath: string, options: GraphQLTagPluckOptions = {}) => {
   if (typeof filePath != 'string') {
@@ -45,7 +53,12 @@ export const gqlPluckFromFile = async (filePath: string, options: GraphQLTagPluc
   filePath = resolve(process.cwd(), filePath);
   options = { ...options, fileExt };
 
-  const code = readFileSync(filePath, { encoding: 'utf8' });
+  let code = readFileSync(filePath, { encoding: 'utf8' });
+
+  if (fileExt === '.vue') {
+    code = pluckVueFileScript(code);
+  }
+
   return gqlPluckFromCodeString(code, options);
 };
 

--- a/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
+++ b/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
@@ -196,6 +196,122 @@ describe('graphql-tag-pluck', () => {
     `))
   })
 
+  it('should pluck graphql-tag template literals from .vue JavaScript file', async () => {
+    const file = await createTmpFile({
+      unsafeCleanup: true,
+      template: '/tmp/tmp-XXXXXX.vue',
+    })
+
+    writeFileSync(file.name, freeText(`
+      <template>
+        <div>test</div>
+      </template>
+
+      <script>
+      import Vue from 'vue'
+      import gql from 'graphql-tag';
+
+      export default Vue.extend({
+        name: 'TestComponent'
+      })
+
+      export const pageQuery = gql\`
+        query IndexQuery {
+          site {
+            siteMetadata {
+              title
+            }
+          }
+        }
+      \`;
+
+      // export const pageQuery = gql\`
+      //   query OtherQuery {
+      //     site {
+      //       siteMetadata {
+      //         title
+      //       }
+      //     }
+      //   }
+      // \`;
+      </script>
+
+      <style>
+      .test { color: red };
+      </style>
+    `))
+
+    const gqlString = await gqlPluck.fromFile(file.name)
+
+    expect(gqlString).toEqual(freeText(`
+      query IndexQuery {
+        site {
+          siteMetadata {
+            title
+          }
+        }
+      }
+    `))
+  })
+
+  it('should pluck graphql-tag template literals from .vue TS/Pug/SCSS file', async () => {
+    const file = await createTmpFile({
+      unsafeCleanup: true,
+      template: '/tmp/tmp-XXXXXX.vue',
+    })
+
+    writeFileSync(file.name, freeText(`
+      <template lang="pug">
+        <div>test</div>
+      </template>
+
+      <script lang="ts">
+      import Vue from 'vue'
+      import gql from 'graphql-tag';
+
+      export default Vue.extend({
+        name: 'TestComponent'
+      })
+
+      export const pageQuery = gql\`
+        query IndexQuery {
+          site {
+            siteMetadata {
+              title
+            }
+          }
+        }
+      \`;
+
+      // export const pageQuery = gql\`
+      //   query OtherQuery {
+      //     site {
+      //       siteMetadata {
+      //         title
+      //       }
+      //     }
+      //   }
+      // \`;
+      </script>
+
+      <style lang="scss">
+      .test { color: red };
+      </style>
+    `))
+
+    const gqlString = await gqlPluck.fromFile(file.name)
+
+    expect(gqlString).toEqual(freeText(`
+      query IndexQuery {
+        site {
+          siteMetadata {
+            title
+          }
+        }
+      }
+    `))
+  })
+
   it('should pluck graphql-tag template literals from .tsx file with generic jsx elements', async () => {
     const file = await createTmpFile({
       unsafeCleanup: true,
@@ -1023,23 +1139,23 @@ describe('graphql-tag-pluck', () => {
     import gql from 'graphql-tag';
 
     export default gql\`
-      type User { 
-        id: ID! 
+      type User {
+        id: ID!
         "Choose a nice username, so users can \\\`@mention\\\` you."
-        username: String! 
-        email: String! 
-      } 
+        username: String!
+        email: String!
+      }
     \`
     `))
 
     const gqlString = await gqlPluck.fromFile(file.name)
 
     expect(gqlString).toEqual(freeText(`
-        type User { 
-          id: ID! 
+        type User {
+          id: ID!
           "Choose a nice username, so users can \`@mention\` you."
-          username: String! 
-          email: String! 
+          username: String!
+          email: String!
         }
     `))
   })

--- a/packages/loaders/code-file/src/index.ts
+++ b/packages/loaders/code-file/src/index.ts
@@ -98,7 +98,7 @@ async function tryToLoadFromCodeAst(filePath: string, options?: CodeFileLoaderOp
 
 export type CodeFileLoaderOptions = { noRequire?: boolean; cwd?: string; require?: string | string[]; pluckConfig?: GraphQLTagPluckOptions };
 
-const CODE_FILE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx'];
+const CODE_FILE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.vue'];
 
 export class CodeFileLoader implements UniversalLoader<CodeFileLoaderOptions> {
   loaderId(): string {


### PR DESCRIPTION
This is a fix for dotansimha/graphql-code-generator#1539 not reading extract gql DocumentNodes from Vue Single File Component files.

This simply uses the `vue-template-compiler` package to get the source of a `<script>` tag in the Vue SFC if the file extension is `.vue`. This was much easier than I expected and it seems to be working well in the tests.

Note: I'm not very familiar with publishing npm packages with optional dependencies, so I don't know the correct way to conditionally import the `vue-template-compiler`. Currently I put it under `optionalDependencies` in the `code-file` loader `package.json`, and use `require` to import the library in the Vue parser code. The `require` in particular is not ideal since it loses the typing. 👎