### PR TITLE
Include directives on enum values in import-parser

### DIFF
--- a/packages/core/src/import-parser/definition.ts
+++ b/packages/core/src/import-parser/definition.ts
@@ -57,6 +57,10 @@ function collectNewTypeDefinitions(allDefinitions: DefinitionNode[], definitionP
     newDefinition.directives.forEach(collectDirective);
   }
 
+  if (newDefinition.kind === 'EnumTypeDefinition') {
+    newDefinition.values.forEach(value => value.directives.forEach(collectDirective));
+  }
+
   if (newDefinition.kind === 'InputObjectTypeDefinition') {
     newDefinition.fields.forEach(collectNode);
   }


### PR DESCRIPTION
Fixes the issue described in https://github.com/ardatan/graphql-import/issues/484