### PR TITLE
Fix typo in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ const document3 = loadDocuments('./src/**/*.graphql', { // load from multiple fi
 
 const document4 = loadDocuments('./src/my-component.ts', {  // load from code file
     loaders: [
-        new CodeFileLoadder()
+        new CodeFileLoader()
     ]
 });
 


### PR DESCRIPTION
While I was trying to understand how CodeFileLoader worked I was confused here: it was being imported in this example but didn't appear in the code (ctrl-f programming).  Slowing down to read the code I spotted the typo.