### PR TITLE
feat: add headers option for apollo-engine loader

### DIFF
--- a/packages/loaders/apollo-engine/src/index.ts
+++ b/packages/loaders/apollo-engine/src/index.ts
@@ -23,6 +23,7 @@ export class ApolloEngineLoader implements SchemaLoader {
         'apollo-client-name': 'Apollo Language Server',
         'apollo-client-reference-id': '146d29c0-912c-46d3-b686-920e52586be6',
         'apollo-client-version': '2.6.8',
+        ...options.headers
       },
       body: JSON.stringify({
         query: SCHEMA_QUERY,


### PR DESCRIPTION
When downloading schema from `apollo-engine` it fails to parse response body. To fix that need to add `content-type: application/json` HTTP Header. Also, would be great if you could add any headers you need.

P.S. I didn't find contribution guide, please point me if any exists, I will fix the PR if needed.